### PR TITLE
Upgrading Gatsby to v4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gatsby-starter-casual
 
-Gatsby.js V2 starter template based on Casual by startbootstrap
+Gatsby.js V4 starter template based on Casual by startbootstrap
 
 For an overview of the project structure please refer to the [Gatsby documentation - Building with Components](https://www.gatsbyjs.org/docs/building-with-components/).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "gatsby-starter-casual",
-    "version": "0.0.1",
-    "description": "Gatsby.js V2 starter template based on Casual by startbootstrap",
+    "version": "0.0.2",
+    "description": "Gatsby.js V4 starter template based on Casual by startbootstrap",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/anubhavsrivastava/gatsby-starter-casual.git"
@@ -11,12 +11,14 @@
         "email": "anubhav.srivastava00@gmail.com"
     },
     "dependencies": {
-        "gatsby": "^2.20.2",
-        "gatsby-plugin-manifest": "^2.3.1",
-        "gatsby-plugin-offline": "^3.1.0",
-        "gatsby-plugin-react-helmet": "^3.2.0",
-        "gatsby-plugin-sass": "^2.2.0",
-        "node-sass": "^4.13.1",
+        "gatsby": "^4.2.0",
+        "gatsby-link": "^4.4.0",
+        "gatsby-plugin-manifest": "^4.2.0",
+        "gatsby-plugin-offline": "^5.2.0",
+        "gatsby-plugin-react-helmet": "^5.2.0",
+        "gatsby-plugin-sass": "^5.2.0",
+        "gatsby-react-router-scroll": "^5.4.0",
+        "node-sass": "^6.0.1",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "react-helmet": "^5.2.1",
@@ -34,8 +36,8 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "devDependencies": {
-        "gh-pages": "^2.2.0",
-        "prettier": "^1.19.1",
+        "gh-pages": "^3.2.3",
+        "prettier": "^2.4.1",
         "rimraf": "^3.0.2"
     },
     "keywords": [


### PR DESCRIPTION
Updates Gatsby to v4.2.0.

Updates selected additional packages to newer versions to account for Gatsby version change.

This update does not change any of the SASS deprecation warnings and any other warnings.  Those will be in a future PR.